### PR TITLE
fix cd in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ After restarting your computer
     ```
     source venv/bin/activate
     ```
-3. Go to the django_pos folder: `cd ultimate_pos`
+3. Go to the django_pos folder: `cd django_pos`
 
 4. Make database migrations:  
   `python manage.py makemigrations` and 


### PR DESCRIPTION
changed instructions under `##run it locally` on readme from Go to the django_pos folder: `cd ultimate_pos` to  `cd django_pos` where django app is located