### PR TITLE
Strictly api

### DIFF
--- a/django_pos/products/serializers.py
+++ b/django_pos/products/serializers.py
@@ -31,4 +31,5 @@ class ProductSerializer(serializers.ModelSerializer):
             "tax_group",
             "tax_rate",
             "get_sku",
+            "id",
         )

--- a/ultimate_pos_frontend/app/products/[id]/page.tsx
+++ b/ultimate_pos_frontend/app/products/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function ProductDetailPage() {
+  return <div>Product Detail Page</div>;
+}

--- a/ultimate_pos_frontend/app/sales/page.tsx
+++ b/ultimate_pos_frontend/app/sales/page.tsx
@@ -175,7 +175,7 @@ export default function SalesPage() {
   );
   const avgTaxRate =
     salesData.length > 0
-      ? salesData.reduce((sum, sale) => sum + sale.tax_percentage, 0) /
+      ? salesData.reduce((sum, sale) => sum + sale.total_tax, 0) /
         salesData.length
       : 0;
 
@@ -451,7 +451,7 @@ export default function SalesPage() {
                             </div>
                             <div className="text-xs text-muted-foreground">
                               Tax: {formatCurrency(sale.tax_amount)} (
-                              {sale.tax_percentage}%)
+                              {sale.total_tax}%)
                               {sale.discount > 0 &&
                                 ` • Discount: ${formatCurrency(sale.discount)}`}
                             </div>

--- a/ultimate_pos_frontend/lib/interfaces/sale.ts
+++ b/ultimate_pos_frontend/lib/interfaces/sale.ts
@@ -6,7 +6,7 @@ export interface Sale {
   sub_total: number;
   grand_total: number;
   tax_amount: number;
-  tax_percentage: number;
+  total_tax: number;
   receipt_is_printed: boolean;
   discount: number;
 }


### PR DESCRIPTION
This pull request introduces updates to both the backend and frontend to improve product and sales data handling and display. The main changes include updating the product serializer to expose the product `id`, refactoring how tax information is represented in the sales interface and related components, and adding a placeholder for the product detail page in the frontend.

**Sales Data Tax Representation Updates:**

* Changed the sales interface (`Sale` in `sale.ts`) to use `total_tax` instead of `tax_percentage` for tax information, aligning the data model with the new representation.
* Updated the sales page (`sales/page.tsx`) to use `total_tax` for calculating average tax rate and displaying tax information, replacing previous usage of `tax_percentage`. [[1]](diffhunk://#diff-c1364367b5419f1d400bb1d651ce59422865406fc28bf7d46ad2ec327d5fb453L178-R178) [[2]](diffhunk://#diff-c1364367b5419f1d400bb1d651ce59422865406fc28bf7d46ad2ec327d5fb453L454-R454)

**Product Serializer and Frontend Improvements:**

* Added the `id` field to the product serializer's output in `products/serializers.py`, making product IDs available in API responses.
* Added a new `ProductDetailPage` component as a placeholder for future product detail functionality in the frontend. ([ultimate_pos_frontend/app/products/[id]/page.tsxR1-R3](diffhunk://#diff-2ce1ead3900eb442e2721cb0fedd690c0c74a26d7a0ad2ad0cf6f68a45616a59R1-R3))